### PR TITLE
Bump actions/cache from 3.0.7 to 3.0.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Cache Qt
         id: cache-qt
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: ${{ runner.workspace }}\Qt
           key: Qt-5.15.2-QtCache
@@ -69,7 +69,7 @@ jobs:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: Installing Jom
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-qt.outputs.cache-hit != 'true'
         run: SandboxiePlus\install_jom.cmd
 
       - name: Build Sandboxie-Plus 64 bit


### PR DESCRIPTION
* Bump actions/cache from 3.0.7 to 3.0.8

Bumps [actions/cache](https://github.com/actions/cache) from 3.0.7 to 3.0.8.
- [Release notes](https://github.com/actions/cache/releases)
- [Changelog](https://github.com/actions/cache/blob/main/RELEASES.md)
- [Commits](https://github.com/actions/cache/compare/v3.0.7...v3.0.8)

---
updated-dependencies:
- dependency-name: actions/cache
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Thank you for your contribution to the Sandboxie repository.

In order to reduce the risk of accidental merges, it's highly recommended for beginners to open a new Pull Request in draft state by clicking the button "Create Draft Pull Request", instead of using the default "Create Pull Request" option. 

In addition, you can convert an existing pull request to a draft by clicking the "Convert to draft" link in the right sidebar under "Reviewers".

All new translators are encouraged to look at the "Localization notes and tips" before creating a pull request: https://git.io/J9G19
